### PR TITLE
Fix rocm path detection in `get_rocm_path`

### DIFF
--- a/numba/hip/hipconfig.py
+++ b/numba/hip/hipconfig.py
@@ -121,10 +121,10 @@ def get_rocm_path(*subdirs):
             "neither 'ROCM_PATH' nor 'ROCM_HOME' environment variable specified, trying default path '/opt/rocm'"
         )
         rocm_path = "/opt/rocm/"
-        if not os.path.exists(rocm_path):
-            msg = "no ROCm installation found, checked 'ROCM_PATH' and 'ROCM_HOME' and tried '/opt/rocm'"
-            _log.error(msg)
-            raise FileNotFoundError(msg)
+    if not os.path.exists(rocm_path):
+        msg = "no ROCm installation found, checked 'ROCM_PATH' and 'ROCM_HOME' and tried '/opt/rocm'"
+        _log.error(msg)
+        raise FileNotFoundError(msg)
 
     if all((isinstance(s, str) for s in subdirs)):
         subdirs = [subdirs]

--- a/numba/hip/hipconfig.py
+++ b/numba/hip/hipconfig.py
@@ -120,11 +120,11 @@ def get_rocm_path(*subdirs):
         _log.info(
             "neither 'ROCM_PATH' nor 'ROCM_HOME' environment variable specified, trying default path '/opt/rocm'"
         )
-    rocm_path = "/opt/rocm/"
-    if not os.path.exists(rocm_path):
-        msg = "no ROCm installation found, checked 'ROCM_PATH' and 'ROCM_HOME' and tried '/opt/rocm'"
-        _log.error(msg)
-        raise FileNotFoundError(msg)
+        rocm_path = "/opt/rocm/"
+        if not os.path.exists(rocm_path):
+            msg = "no ROCm installation found, checked 'ROCM_PATH' and 'ROCM_HOME' and tried '/opt/rocm'"
+            _log.error(msg)
+            raise FileNotFoundError(msg)
 
     if all((isinstance(s, str) for s in subdirs)):
         subdirs = [subdirs]


### PR DESCRIPTION
Currently, get_rocm_path raises an error if no installation exists at `/opt/rocm/`, even if `ROCM_HOME` or `ROCM_PATH` is set.

I'm in a situation where I cannot add an install at that path, so a fix like this would be lovely.