### PR TITLE
Upgrade to version 0.1.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,39 @@
+# MIT License
+#
+# Modifications Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 repos:
+- repo: local
+  hooks:
+        - id: check-license-installation
+          name: check-license-installation
+          entry: bash -c "type license_verificator >/dev/null 2>&1 || echo \"[WARNING] license verificator not installed!\" || true"
+          language: system
+          verbose: true
+          pass_filenames: false
+        - id: amd-copyright
+          name: amd-copyright
+          entry: bash -c "(! type license_verificator >/dev/null 2>&1) || license_verificator --pre-commit"
+          language: system
+          pass_filenames: false
 - repo: https://github.com/psf/black
   rev: 25.1.0
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# numba-hip 0.1.6 (09 Feb 2026)
+
+* Add fallback option to use AMD-SMI for UUID detection.
+* Extend ROCm support metadata with keys for ROCm 7.1.1 and 7.2.0.
+* Documentation: update tested GPUs and supported Numba versions.
+
+# numba-hip 0.1.5 (29 Jan 2026)
+
+## Bug Fixes
+
+* Fix `__array__()` method for NumPy 2.0 compatibility.
+* Add ROCm 7.2 data layout to `test_amdgcn`.
+
+# numba-hip 0.1.4 (09 Dec 2025)
+
+* Add Python 3.13 compatibility.
+* Vendor HIP sigutils and switch HIP modules to use it.
+* Move `devicefunc` and `dummyarray` into numba-hip.
+* hipdrv: remove `modulerepl*`, use local module files.
+* Documentation: extend support note with tested RDNA3/4 cards.
+* Developer tooling: add `license_verificator` to pre-commit hooks.
+
+## Bug Fixes
+
+* Fix HIPDispatcher specialization typing to use `typeof_pyval`.
+* tests(hipdrv): fix empty-slice assertions to validate array size.
+
 # numba-hip 0.1.3 (07 Oct 2025)
 
 * Compatiblity with ROCm 7.0.*.

--- a/README.rst
+++ b/README.rst
@@ -2,14 +2,33 @@
 Numba HIP
 *********
 
-This repository provides a ROCm(TM) HIP backend for Numba.
+This repository provides a ROCm™ HIP backend for Numba.
 
-.. note:: Only for AMD MI series GPUs on Linux systems
+.. admonition:: **For AMD GPUs on Linux**
 
-    So far the Numba HIP backend has only been used and tested with AMD MI series GPUs
-    on Linux systems. CUDA(R) devices are not supported.
+    The Numba HIP backend has been tested on systems with AMD Instinct™, AMD Radeon™ RDNA3, and AMD Radeon™ RDNA4 accelerators
+    on ROCm 7.0 and ROCm 7.1.
 
-.. note:: Experimental project
+    The following AMD Radeon™ RDNA3 cards have been tested on ROCm 7.1:
+ 
+    * AMD Radeon™ RX 7900 XTX
+    * AMD Radeon™ RX 7900 XT
+    * AMD Radeon™ PRO W7900D
+    * AMD Radeon™ PRO V710
+
+    The following AMD Radeon™ RDNA4 cards have been tested on ROCm 7.1:
+
+    * AMD Radeon™ RX 9060 XT
+    * AMD Radeon™ AI PRO R9700
+
+    The following AMD Instinct™ accelerators have been tested on ROCm 7.0 and ROCm 7.1:
+
+    * AMD Instinct™ MI210
+    * AMD Instinct™ MI300X
+
+    CUDA® devices are not supported by Numba HIP.
+
+.. admonition:: **Experimental project**
     
     With this release, we primarily want to accomplish two things:
 

--- a/README.rst
+++ b/README.rst
@@ -6,46 +6,51 @@ This repository provides a ROCm™ HIP backend for Numba.
 
 .. admonition:: **For AMD GPUs on Linux**
 
-    The Numba HIP backend has been tested on systems with AMD Instinct™, AMD Radeon™ RDNA3, and AMD Radeon™ RDNA4 accelerators
-    on ROCm 7.0 and ROCm 7.1.
+    Numba HIP is for AMD Radeon™ and AMD Instinct™ accelerators.
+    CUDA® devices are not supported by Numba HIP.
 
-    The following AMD Radeon™ RDNA3 cards have been tested on ROCm 7.1:
+    As Numba HIP generates LLVM bitcode device libraries on-the-fly via the
+    ROCm compiler and delegates runtime tasks to the HIP runtime via the HIP
+    Python bindings, it does itself not pose any limitation on the
+    supported AMD GPU devices.
+
+    The ROCm on Radeon QA team has tested Numba HIP 0.1.4 on systems 
+    with AMD Radeon™ RDNA3, and AMD Radeon™ RDNA4 accelerators ROCm 7.1.0.
+    The QA team's testing focused on the following AMD Radeon™ cards:
  
     * AMD Radeon™ RX 7900 XTX
     * AMD Radeon™ RX 7900 XT
     * AMD Radeon™ PRO W7900D
     * AMD Radeon™ PRO V710
-
-    The following AMD Radeon™ RDNA4 cards have been tested on ROCm 7.1:
-
     * AMD Radeon™ RX 9060 XT
     * AMD Radeon™ AI PRO R9700
 
-    The following AMD Instinct™ accelerators have been tested on ROCm 7.0 and ROCm 7.1:
+    The authors have tested all versions of Numba HIP before version 0.1.4
+    (so for ROCM versions before 7.1.1) predominantly on systems with
+    AMD Instinct™ MI210X (gfx90a).
+    
+    The authors have tested Numba HIP 0.1.6 on ROCm 7.1.1 and ROCm 7.2.0
+    systems with the following architectures:
 
-    * AMD Instinct™ MI210
-    * AMD Instinct™ MI300X
-
-    CUDA® devices are not supported by Numba HIP.
+    * gfx1030v (AMD Radeon™ PRO V620)
+    * gfx1100p (AMD Radeon™ PRO W7800)
+    * gfx1102 (AMD Radeon™ RX 7600 XT)
+    * gfx1201 (AMD Radeon™ RX 9070 XT)
+    * gfx90a (AMD Instinct™ MI210X/MI250
+    * gfx942 (AMD Instinct™ MI300A/MI300X/MI308X/MI325X)
 
 .. admonition:: **Experimental project**
     
-    With this release, we primarily want to accomplish two things:
-
-    1. Support internal projects that require a Numba backend for AMD GPUs.
-       All features that have been implemented so far were driven by the
-       requirements of those internal projects.
-    2. Give Numba developers additional context on how to create infrastructure that
-       supports multiple accelerator targets.
-       (See also: `RFC: Moving the CUDA target to a new package maintained by NVIDIA <https://numba.discourse.group/t/rfc-moving-the-cuda-target-to-a-new-package-maintained-by-nvidia/2628/2>`_)
+    This project primarily aims to support the AMD ROCm™ Data Science toolkit
+    (`ROCm-DS <https://rocm.docs.amd.com/projects/rocm-ds/en/latest/index.html>`_)
+    Most features that have been implemented were driven by ROCm-DS.
     
     However, we are also happy to get feedback from early adopters on their experience with the new Numba HIP backend.
-    So if you give Numba HIP a try, let us know about your experience. We are looking forward to your suggestions, issue reports, and
-    pull requests!
-
+    So if you give Numba HIP a try, let us know about your experience. We are looking forward to receiving 
+    your suggestions, issue reports, and pull requests.
 
 About Numba: A Just-In-Time Compiler for Numerical Functions in Python
-######################################################################
+======================================================================
 
 Numba is an open source, NumPy-aware optimizing compiler for Python sponsored
 by Anaconda, Inc.  It uses the LLVM compiler project to generate machine code
@@ -173,7 +178,7 @@ Installation
    * 0.58.*
    * 0.59.*
    * 0.60.0
-   * 0.61.2
+   * 0.61.2 (Numba HIP 0.1.5+)
 
    Other versions have not been tested; using the Numba HIP backend with these versions might work or not.
 
@@ -199,7 +204,7 @@ We use optional dependency lists to make this configurable; see the
 ``pyproject.toml`` file for more details.
 To install dependencies for a ROCm release of a particular version, you need
 to specify an dependency key in the format
-``rocm-<major>-<minor>-<patch>`` (example: ``rocm-6-1-2``) when building
+``rocm-<major>-<minor>-<patch>`` (example: ``rocm-7-2-0``) when building
 the Numba HIP package. If you leave the key aside, ``pip`` will either use
 already installed versions of the dependencies or install the latest release
 of these dependencies, which are compatible with the most recent release of ROCm
@@ -217,13 +222,13 @@ optionally the branch that you want to build directly to ``pip``:
    pip config set global.extra-index-url https://test.pypi.org/simple
    # syntax 1: pip install git+<URL>@<branch>
    # syntax 2: pip install "numba-hip[rocm-<major>-<minor>-<patch>] @ git+<URL>@<branch>"
-   pip install "numba-hip[rocm-6-1-2] @ git+https://github.com/ROCm/numba-hip.git"
+   pip install "numba-hip[rocm-7-2-0] @ git+https://github.com/ROCm/numba-hip.git"
      # alternatively: checkout a branch like 'dev':
-     # pip install "numba-hip[rocm-6-1-2] @ git+https://github.com/ROCm/numba-hip.git@dev"
+     # pip install "numba-hip[rocm-7-2-0] @ git+https://github.com/ROCm/numba-hip.git@dev"
 
 .. note:: ROCm key must agree with your environment
 
-   Do not forget to change the ROCm version ``rocm-6-1-2``
+   Do not forget to change the ROCm version ``rocm-7-2-0``
    (format: ``rocm-<major>-<minor>-<patch>``) to a key that agrees with your
    ROCm installation so that dependency versions compatible with your
    ROCm installation are installed by ``pip``.
@@ -236,9 +241,9 @@ Install with optional test dependencies:
    pip config set global.extra-index-url https://test.pypi.org/simple
    # syntax 1: pip install "numba-hip[test] @  git+<URL>@<branch>"
    # syntax 2: pip install "numba-hip[rocm-<major>-<minor>-<patch>,test] @ git+<URL>@<branch>"
-   pip install "numba-hip[rocm-6-1-2,test] @ git+https://github.com/ROCm/numba-hip.git"
+   pip install "numba-hip[rocm-7-2-0,test] @ git+https://github.com/ROCm/numba-hip.git"
      # alternatively: checkout a branch like 'dev':
-     # pip install "numba-hip[rocm-6-1-2,test] @ git+https://github.com/ROCm/numba-hip.git@dev"
+     # pip install "numba-hip[rocm-7-2-0,test] @ git+https://github.com/ROCm/numba-hip.git@dev"
 
 Install via pip install
 -----------------------
@@ -252,14 +257,14 @@ After cloning the repository, you can also install the package via ``pip install
      # pip clone https://github.com/ROCm/numba-hip.git -b branch
    pip install --upgrade pip
    pip config set global.extra-index-url https://test.pypi.org/simple
-   python3 -m pip install .[rocm-6-1-2]
+   python3 -m pip install .[rocm-7-2-0]
      # alternatively: install optional test dependencies:
      # variant 1: python3 -m pip install .[test]
-     # variant 2: python3 -m pip install .[rocm-6-1-2,test]
+     # variant 2: python3 -m pip install .[rocm-7-2-0,test]
 
 .. note:: ROCm key must agree with your environment
 
-   Do not forget to change the ROCm version ``rocm-6-1-2``
+   Do not forget to change the ROCm version ``rocm-7-2-0``
    (format: ``rocm-<major>-<minor>-<patch>``) to a key that agrees with your
    ROCm installation so that dependency versions compatible with your
    ROCm installation are installed by ``pip``.
@@ -283,11 +288,11 @@ and then distribute it (or install it):
    # optional: install the wheel:
    pip install dist/*.whl
    # alternatively: install optional test dependencies:
-   # pip3 install dist/numba_hip-0.1-py3-none-any.whl[rocm-6-1-2]
+   # pip3 install dist/numba_hip-0.1-py3-none-any.whl[rocm-7-2-0]
 
 .. note:: ROCm key must agree with your environment
 
-   Do not forget to change the ROCm version ``rocm-6-1-2``
+   Do not forget to change the ROCm version ``rocm-7-2-0``
    (format: ``rocm-<major>-<minor>-<patch>``) to a key that agrees with your
    ROCm installation so that dependency versions compatible with your
    ROCm installation are installed by ``pip``.

--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,7 @@ Installation
    * 0.58.*
    * 0.59.*
    * 0.60.0
+   * 0.61.2
 
    Other versions have not been tested; using the Numba HIP backend with these versions might work or not.
 

--- a/numba/hip/compiler.py
+++ b/numba/hip/compiler.py
@@ -25,7 +25,7 @@
 
 # MIT License
 #
-# Modifications Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Modifications Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -51,7 +51,6 @@ from numba.core import config  # noqa: F401
 from numba.core import (
     compiler,
     funcdesc,
-    sigutils,
     types,
     typing,
 )
@@ -79,6 +78,7 @@ from numba.core.typing.templates import ConcreteTemplate
 
 from numba.hip import codegen, hipconfig, target
 from numba.hip.api import get_current_device
+from numba.hip.core import sigutils
 
 
 def _options_type(x):

--- a/numba/hip/core/sigutils.py
+++ b/numba/hip/core/sigutils.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from numba.core import types, typing
+
+
+def is_signature(sig):
+    """
+    Return whether *sig* is a potentially valid signature
+    specification (for user-facing APIs).
+    """
+    return isinstance(sig, (str, tuple, typing.Signature))
+
+
+def _parse_signature_string(signature_str):
+    """
+    Parameters
+    ----------
+    signature_str : str
+    """
+    # Just eval signature_str using the types submodules as globals
+    return eval(signature_str, {}, types.__dict__)
+
+
+def normalize_signature(sig):
+    """
+    From *sig* (a signature specification), return a ``(args, return_type)``
+    tuple, where ``args`` itself is a tuple of types, and ``return_type``
+    can be None if not specified.
+    """
+    if isinstance(sig, str):
+        parsed = _parse_signature_string(sig)
+    else:
+        parsed = sig
+    if isinstance(parsed, tuple):
+        args, return_type = parsed, None
+    elif isinstance(parsed, typing.Signature):
+        args, return_type = parsed.args, parsed.return_type
+    else:
+        raise TypeError(
+            "invalid signature: %r (type: %r) evaluates to %r "
+            "instead of tuple or Signature"
+            % (sig, sig.__class__.__name__, parsed.__class__.__name__)
+        )
+
+    def check_type(ty):
+        if not isinstance(ty, types.Type):
+            raise TypeError(
+                "invalid type in signature: expected a type "
+                "instance, got %r" % (ty,)
+            )
+
+    if return_type is not None:
+        check_type(return_type)
+    for ty in args:
+        check_type(ty)
+
+    return args, return_type

--- a/numba/hip/decorators.py
+++ b/numba/hip/decorators.py
@@ -25,7 +25,7 @@
 
 # MIT License
 #
-# Modifications Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Modifications Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -47,10 +47,11 @@
 
 from warnings import warn
 
-from numba.core import config, sigutils, types
+from numba.core import config, types
 from numba.core.errors import DeprecationError, NumbaInvalidConfigWarning
 
 from numba.hip.compiler import declare_device_function
+from numba.hip.core import sigutils
 from numba.hip.dispatcher import HIPDispatcher
 
 # from numba.hip.simulator.kernel import FakeHIPKernel # TODO support simulator

--- a/numba/hip/deviceufunc.py
+++ b/numba/hip/deviceufunc.py
@@ -1,0 +1,957 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Implements custom ufunc dispatch mechanism for non-CPU devices.
+"""
+
+from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
+import operator
+import warnings
+from functools import reduce
+
+import numpy as np
+
+from numba.np.ufunc.ufuncbuilder import _BaseUFuncBuilder, parse_identity
+from numba.core import types
+from numba.core.typing import signature
+from numba.cuda.core import sigutils
+from numba.np.ufunc.sigparse import parse_signature
+
+
+def _broadcast_axis(a, b):
+    """
+    Raises
+    ------
+    ValueError if broadcast fails
+    """
+    if a == b:
+        return a
+    elif a == 1:
+        return b
+    elif b == 1:
+        return a
+    else:
+        raise ValueError("failed to broadcast {0} and {1}".format(a, b))
+
+
+def _pairwise_broadcast(shape1, shape2):
+    """
+    Raises
+    ------
+    ValueError if broadcast fails
+    """
+    shape1, shape2 = map(tuple, [shape1, shape2])
+
+    while len(shape1) < len(shape2):
+        shape1 = (1,) + shape1
+
+    while len(shape1) > len(shape2):
+        shape2 = (1,) + shape2
+
+    return tuple(_broadcast_axis(a, b) for a, b in zip(shape1, shape2))
+
+
+def _multi_broadcast(*shapelist):
+    """
+    Raises
+    ------
+    ValueError if broadcast fails
+    """
+    assert shapelist
+
+    result = shapelist[0]
+    others = shapelist[1:]
+    try:
+        for i, each in enumerate(others, start=1):
+            result = _pairwise_broadcast(result, each)
+    except ValueError:
+        raise ValueError("failed to broadcast argument #{0}".format(i))
+    else:
+        return result
+
+
+class UFuncMechanism(object):
+    """
+    Prepare ufunc arguments for vectorize.
+    """
+
+    DEFAULT_STREAM = None
+    SUPPORT_DEVICE_SLICING = False
+
+    def __init__(self, typemap, args):
+        """Never used directly by user. Invoke by UFuncMechanism.call()."""
+        self.typemap = typemap
+        self.args = args
+        nargs = len(self.args)
+        self.argtypes = [None] * nargs
+        self.scalarpos = []
+        self.signature = None
+        self.arrays = [None] * nargs
+
+    def _fill_arrays(self):
+        """
+        Get all arguments in array form
+        """
+        for i, arg in enumerate(self.args):
+            if self.is_device_array(arg):
+                self.arrays[i] = self.as_device_array(arg)
+            elif isinstance(arg, (int, float, complex, np.number)):
+                # Is scalar
+                self.scalarpos.append(i)
+            else:
+                self.arrays[i] = np.asarray(arg)
+
+    def _fill_argtypes(self):
+        """
+        Get dtypes
+        """
+        for i, ary in enumerate(self.arrays):
+            if ary is not None:
+                dtype = getattr(ary, "dtype")
+                if dtype is None:
+                    dtype = np.asarray(ary).dtype
+                self.argtypes[i] = dtype
+
+    def _resolve_signature(self):
+        """Resolve signature.
+        May have ambiguous case.
+        """
+        matches = []
+        # Resolve scalar args exact match first
+        if self.scalarpos:
+            # Try resolve scalar arguments
+            for formaltys in self.typemap:
+                match_map = []
+                for i, (formal, actual) in enumerate(
+                    zip(formaltys, self.argtypes)
+                ):
+                    if actual is None:
+                        actual = np.asarray(self.args[i]).dtype
+
+                    match_map.append(actual == formal)
+
+                if all(match_map):
+                    matches.append(formaltys)
+
+        # No matching with exact match; try coercing the scalar arguments
+        if not matches:
+            matches = []
+            for formaltys in self.typemap:
+                all_matches = all(
+                    actual is None or formal == actual
+                    for formal, actual in zip(formaltys, self.argtypes)
+                )
+                if all_matches:
+                    matches.append(formaltys)
+
+        if not matches:
+            raise TypeError(
+                "No matching version.  GPU ufunc requires array "
+                "arguments to have the exact types.  This behaves "
+                "like regular ufunc with casting='no'."
+            )
+
+        if len(matches) > 1:
+            raise TypeError(
+                "Failed to resolve ufunc due to ambiguous "
+                "signature. Too many untyped scalars. "
+                "Use numpy dtype object to type tag."
+            )
+
+        # Try scalar arguments
+        self.argtypes = matches[0]
+
+    def _get_actual_args(self):
+        """Return the actual arguments
+        Casts scalar arguments to np.array.
+        """
+        for i in self.scalarpos:
+            self.arrays[i] = np.array([self.args[i]], dtype=self.argtypes[i])
+
+        return self.arrays
+
+    def _broadcast(self, arys):
+        """Perform numpy ufunc broadcasting"""
+        shapelist = [a.shape for a in arys]
+        shape = _multi_broadcast(*shapelist)
+
+        for i, ary in enumerate(arys):
+            if ary.shape == shape:
+                pass
+
+            else:
+                if self.is_device_array(ary):
+                    arys[i] = self.broadcast_device(ary, shape)
+
+                else:
+                    ax_differs = [
+                        ax
+                        for ax in range(len(shape))
+                        if ax >= ary.ndim or ary.shape[ax] != shape[ax]
+                    ]
+
+                    missingdim = len(shape) - len(ary.shape)
+                    strides = [0] * missingdim + list(ary.strides)
+
+                    for ax in ax_differs:
+                        strides[ax] = 0
+
+                    strided = np.lib.stride_tricks.as_strided(
+                        ary, shape=shape, strides=strides
+                    )
+
+                    arys[i] = self.force_array_layout(strided)
+
+        return arys
+
+    def get_arguments(self):
+        """Prepare and return the arguments for the ufunc.
+        Does not call to_device().
+        """
+        self._fill_arrays()
+        self._fill_argtypes()
+        self._resolve_signature()
+        arys = self._get_actual_args()
+        return self._broadcast(arys)
+
+    def get_function(self):
+        """Returns (result_dtype, function)"""
+        return self.typemap[self.argtypes]
+
+    def is_device_array(self, obj):
+        """Is the `obj` a device array?
+        Override in subclass
+        """
+        return False
+
+    def as_device_array(self, obj):
+        """Convert the `obj` to a device array
+        Override in subclass
+
+        Default implementation is an identity function
+        """
+        return obj
+
+    def broadcast_device(self, ary, shape):
+        """Handles ondevice broadcasting
+
+        Override in subclass to add support.
+        """
+        raise NotImplementedError("broadcasting on device is not supported")
+
+    def force_array_layout(self, ary):
+        """Ensures array layout met device requirement.
+
+        Override in sublcass
+        """
+        return ary
+
+    @classmethod
+    def call(cls, typemap, args, kws):
+        """Perform the entire ufunc call mechanism."""
+        # Handle keywords
+        stream = kws.pop("stream", cls.DEFAULT_STREAM)
+        out = kws.pop("out", None)
+
+        if kws:
+            warnings.warn("unrecognized keywords: %s" % ", ".join(kws))
+
+        # Begin call resolution
+        cr = cls(typemap, args)
+        args = cr.get_arguments()
+        resty, func = cr.get_function()
+
+        outshape = args[0].shape
+
+        # Adjust output value
+        if out is not None and cr.is_device_array(out):
+            out = cr.as_device_array(out)
+
+        def attempt_ravel(a):
+            if cr.SUPPORT_DEVICE_SLICING:
+                raise NotImplementedError
+
+            try:
+                # Call the `.ravel()` method
+                return a.ravel()
+            except NotImplementedError:
+                # If it is not a device array
+                if not cr.is_device_array(a):
+                    raise
+                # For device array, retry ravel on the host by first
+                # copying it back.
+                else:
+                    hostary = cr.to_host(a, stream).ravel()
+                    return cr.to_device(hostary, stream)
+
+        if args[0].ndim > 1:
+            args = [attempt_ravel(a) for a in args]
+
+        # Prepare argument on the device
+        devarys = []
+        any_device = False
+        for a in args:
+            if cr.is_device_array(a):
+                devarys.append(a)
+                any_device = True
+            else:
+                dev_a = cr.to_device(a, stream=stream)
+                devarys.append(dev_a)
+
+        # Launch
+        shape = args[0].shape
+        if out is None:
+            # No output is provided
+            devout = cr.allocate_device_array(shape, resty, stream=stream)
+
+            devarys.extend([devout])
+            cr.launch(func, shape[0], stream, devarys)
+
+            if any_device:
+                # If any of the arguments are on device,
+                # Keep output on the device
+                return devout.reshape(outshape)
+            else:
+                # Otherwise, transfer output back to host
+                return devout.copy_to_host().reshape(outshape)
+
+        elif cr.is_device_array(out):
+            # If output is provided and it is a device array,
+            # Return device array
+            if out.ndim > 1:
+                out = attempt_ravel(out)
+            devout = out
+            devarys.extend([devout])
+            cr.launch(func, shape[0], stream, devarys)
+            return devout.reshape(outshape)
+
+        else:
+            # If output is provided and it is a host array,
+            # Return host array
+            assert out.shape == shape
+            assert out.dtype == resty
+            devout = cr.allocate_device_array(shape, resty, stream=stream)
+            devarys.extend([devout])
+            cr.launch(func, shape[0], stream, devarys)
+            return devout.copy_to_host(out, stream=stream).reshape(outshape)
+
+    def to_device(self, hostary, stream):
+        """Implement to device transfer
+        Override in subclass
+        """
+        raise NotImplementedError
+
+    def to_host(self, devary, stream):
+        """Implement to host transfer
+        Override in subclass
+        """
+        raise NotImplementedError
+
+    def allocate_device_array(self, shape, dtype, stream):
+        """Implements device allocation
+        Override in subclass
+        """
+        raise NotImplementedError
+
+    def launch(self, func, count, stream, args):
+        """Implements device function invocation
+        Override in subclass
+        """
+        raise NotImplementedError
+
+
+def to_dtype(ty):
+    if isinstance(ty, types.EnumMember):
+        ty = ty.dtype
+    return np.dtype(str(ty))
+
+
+class DeviceVectorize(_BaseUFuncBuilder):
+    def __init__(self, func, identity=None, cache=False, targetoptions={}):
+        if cache:
+            raise TypeError("caching is not supported")
+        for opt in targetoptions:
+            if opt == "nopython":
+                warnings.warn(
+                    "nopython kwarg for cuda target is redundant",
+                    RuntimeWarning,
+                )
+            else:
+                fmt = "Unrecognized options. "
+                fmt += "cuda vectorize target does not support option: '%s'"
+                raise KeyError(fmt % opt)
+        self.py_func = func
+        self.identity = parse_identity(identity)
+        # { arg_dtype: (return_dtype), cudakernel }
+        self.kernelmap = OrderedDict()
+
+    @property
+    def pyfunc(self):
+        return self.py_func
+
+    def add(self, sig=None):
+        # compile core as device function
+        args, return_type = sigutils.normalize_signature(sig)
+        devfnsig = signature(return_type, *args)
+
+        funcname = self.pyfunc.__name__
+        kernelsource = self._get_kernel_source(
+            self._kernel_template, devfnsig, funcname
+        )
+        corefn, return_type = self._compile_core(devfnsig)
+        glbl = self._get_globals(corefn)
+        sig = signature(types.void, *([a[:] for a in args] + [return_type[:]]))
+        exec(kernelsource, glbl)
+
+        stager = glbl["__vectorized_%s" % funcname]
+        kernel = self._compile_kernel(stager, sig)
+
+        argdtypes = tuple(to_dtype(t) for t in devfnsig.args)
+        resdtype = to_dtype(return_type)
+        self.kernelmap[tuple(argdtypes)] = resdtype, kernel
+
+    def build_ufunc(self):
+        raise NotImplementedError
+
+    def _get_kernel_source(self, template, sig, funcname):
+        args = ["a%d" % i for i in range(len(sig.args))]
+        fmts = dict(
+            name=funcname,
+            args=", ".join(args),
+            argitems=", ".join("%s[__tid__]" % i for i in args),
+        )
+        return template.format(**fmts)
+
+    def _compile_core(self, sig):
+        raise NotImplementedError
+
+    def _get_globals(self, corefn):
+        raise NotImplementedError
+
+    def _compile_kernel(self, fnobj, sig):
+        raise NotImplementedError
+
+
+class DeviceGUFuncVectorize(_BaseUFuncBuilder):
+    def __init__(
+        self,
+        func,
+        sig,
+        identity=None,
+        cache=False,
+        targetoptions={},
+        writable_args=(),
+    ):
+        if cache:
+            raise TypeError("caching is not supported")
+        if writable_args:
+            raise TypeError("writable_args are not supported")
+
+        # Allow nopython flag to be set.
+        if not targetoptions.pop("nopython", True):
+            raise TypeError("nopython flag must be True")
+        # Are there any more target options?
+        if targetoptions:
+            opts = ", ".join([repr(k) for k in targetoptions.keys()])
+            fmt = "The following target options are not supported: {0}"
+            raise TypeError(fmt.format(opts))
+
+        self.py_func = func
+        self.identity = parse_identity(identity)
+        self.signature = sig
+        self.inputsig, self.outputsig = parse_signature(self.signature)
+
+        # Maps from a tuple of input_dtypes to (output_dtypes, kernel)
+        self.kernelmap = OrderedDict()
+
+    @property
+    def pyfunc(self):
+        return self.py_func
+
+    def add(self, sig=None):
+        indims = [len(x) for x in self.inputsig]
+        outdims = [len(x) for x in self.outputsig]
+        args, return_type = sigutils.normalize_signature(sig)
+
+        # It is only valid to specify types.none as a return type, or to not
+        # specify the return type (where the "Python None" is the return type)
+        valid_return_type = return_type in (types.none, None)
+        if not valid_return_type:
+            raise TypeError(
+                "guvectorized functions cannot return values: "
+                f"signature {sig} specifies {return_type} return "
+                "type"
+            )
+
+        funcname = self.py_func.__name__
+        src = expand_gufunc_template(
+            self._kernel_template, indims, outdims, funcname, args
+        )
+
+        glbls = self._get_globals(sig)
+
+        exec(src, glbls)
+        fnobj = glbls["__gufunc_{name}".format(name=funcname)]
+
+        outertys = list(_determine_gufunc_outer_types(args, indims + outdims))
+        kernel = self._compile_kernel(fnobj, sig=tuple(outertys))
+
+        nout = len(outdims)
+        dtypes = [np.dtype(str(t.dtype)) for t in outertys]
+        indtypes = tuple(dtypes[:-nout])
+        outdtypes = tuple(dtypes[-nout:])
+
+        self.kernelmap[indtypes] = outdtypes, kernel
+
+    def _compile_kernel(self, fnobj, sig):
+        raise NotImplementedError
+
+    def _get_globals(self, sig):
+        raise NotImplementedError
+
+
+def _determine_gufunc_outer_types(argtys, dims):
+    for at, nd in zip(argtys, dims):
+        if isinstance(at, types.Array):
+            yield at.copy(ndim=nd + 1)
+        else:
+            if nd > 0:
+                raise ValueError("gufunc signature mismatch: ndim>0 for scalar")
+            yield types.Array(dtype=at, ndim=1, layout="A")
+
+
+def expand_gufunc_template(template, indims, outdims, funcname, argtypes):
+    """Expand gufunc source template"""
+    argdims = indims + outdims
+    argnames = ["arg{0}".format(i) for i in range(len(argdims))]
+    checkedarg = "min({0})".format(
+        ", ".join(["{0}.shape[0]".format(a) for a in argnames])
+    )
+    inputs = [
+        _gen_src_for_indexing(aref, adims, atype)
+        for aref, adims, atype in zip(argnames, indims, argtypes)
+    ]
+    outputs = [
+        _gen_src_for_indexing(aref, adims, atype)
+        for aref, adims, atype in zip(
+            argnames[len(indims) :], outdims, argtypes[len(indims) :]
+        )
+    ]
+    argitems = inputs + outputs
+    src = template.format(
+        name=funcname,
+        args=", ".join(argnames),
+        checkedarg=checkedarg,
+        argitems=", ".join(argitems),
+    )
+    return src
+
+
+def _gen_src_for_indexing(aref, adims, atype):
+    return "{aref}[{sliced}]".format(
+        aref=aref, sliced=_gen_src_index(adims, atype)
+    )
+
+
+def _gen_src_index(adims, atype):
+    if adims > 0:
+        return ",".join(["__tid__"] + [":"] * adims)
+    elif isinstance(atype, types.Array) and atype.ndim - 1 == adims:
+        # Special case for 0-nd in shape-signature but
+        # 1d array in type signature.
+        # Slice it so that the result has the same dimension.
+        return "__tid__:(__tid__ + 1)"
+    else:
+        return "__tid__"
+
+
+class GUFuncEngine(object):
+    """Determine how to broadcast and execute a gufunc
+    base on input shape and signature
+    """
+
+    @classmethod
+    def from_signature(cls, signature):
+        return cls(*parse_signature(signature))
+
+    def __init__(self, inputsig, outputsig):
+        # signatures
+        self.sin = inputsig
+        self.sout = outputsig
+        # argument count
+        self.nin = len(self.sin)
+        self.nout = len(self.sout)
+
+    def schedule(self, ishapes):
+        if len(ishapes) != self.nin:
+            raise TypeError("invalid number of input argument")
+
+        # associate symbol values for input signature
+        symbolmap = {}
+        outer_shapes = []
+        inner_shapes = []
+
+        for argn, (shape, symbols) in enumerate(zip(ishapes, self.sin)):
+            argn += 1  # start from 1 for human
+            inner_ndim = len(symbols)
+            if len(shape) < inner_ndim:
+                fmt = "arg #%d: insufficient inner dimension"
+                raise ValueError(fmt % (argn,))
+            if inner_ndim:
+                inner_shape = shape[-inner_ndim:]
+                outer_shape = shape[:-inner_ndim]
+            else:
+                inner_shape = ()
+                outer_shape = shape
+
+            for axis, (dim, sym) in enumerate(zip(inner_shape, symbols)):
+                axis += len(outer_shape)
+                if sym in symbolmap:
+                    if symbolmap[sym] != dim:
+                        fmt = "arg #%d: shape[%d] mismatch argument"
+                        raise ValueError(fmt % (argn, axis))
+                symbolmap[sym] = dim
+
+            outer_shapes.append(outer_shape)
+            inner_shapes.append(inner_shape)
+
+        # solve output shape
+        oshapes = []
+        for outsig in self.sout:
+            oshape = []
+            for sym in outsig:
+                oshape.append(symbolmap[sym])
+            oshapes.append(tuple(oshape))
+
+        # find the biggest outershape as looping dimension
+        sizes = [reduce(operator.mul, s, 1) for s in outer_shapes]
+        largest_i = np.argmax(sizes)
+        loopdims = outer_shapes[largest_i]
+
+        pinned = [False] * self.nin  # same argument for each iteration
+        for i, d in enumerate(outer_shapes):
+            if d != loopdims:
+                if d == (1,) or d == ():
+                    pinned[i] = True
+                else:
+                    fmt = "arg #%d: outer dimension mismatch"
+                    raise ValueError(fmt % (i + 1,))
+
+        return GUFuncSchedule(self, inner_shapes, oshapes, loopdims, pinned)
+
+
+class GUFuncSchedule(object):
+    def __init__(self, parent, ishapes, oshapes, loopdims, pinned):
+        self.parent = parent
+        # core shapes
+        self.ishapes = ishapes
+        self.oshapes = oshapes
+        # looping dimension
+        self.loopdims = loopdims
+        self.loopn = reduce(operator.mul, loopdims, 1)
+        # flags
+        self.pinned = pinned
+
+        self.output_shapes = [loopdims + s for s in oshapes]
+
+    def __str__(self):
+        import pprint
+
+        attrs = "ishapes", "oshapes", "loopdims", "loopn", "pinned"
+        values = [(k, getattr(self, k)) for k in attrs]
+        return pprint.pformat(dict(values))
+
+
+class GeneralizedUFunc(object):
+    def __init__(self, kernelmap, engine):
+        self.kernelmap = kernelmap
+        self.engine = engine
+        self.max_blocksize = 2**30
+
+    def __call__(self, *args, **kws):
+        callsteps = self._call_steps(
+            self.engine.nin, self.engine.nout, args, kws
+        )
+        indtypes, schedule, outdtypes, kernel = self._schedule(
+            callsteps.inputs, callsteps.outputs
+        )
+        callsteps.adjust_input_types(indtypes)
+
+        outputs = callsteps.prepare_outputs(schedule, outdtypes)
+        inputs = callsteps.prepare_inputs()
+        parameters = self._broadcast(schedule, inputs, outputs)
+
+        callsteps.launch_kernel(kernel, schedule.loopn, parameters)
+
+        return callsteps.post_process_outputs(outputs)
+
+    def _schedule(self, inputs, outs):
+        input_shapes = [a.shape for a in inputs]
+        schedule = self.engine.schedule(input_shapes)
+
+        # find kernel
+        indtypes = tuple(i.dtype for i in inputs)
+        try:
+            outdtypes, kernel = self.kernelmap[indtypes]
+        except KeyError:
+            # No exact match, then use the first compatible.
+            # This does not match the numpy dispatching exactly.
+            # Later, we may just jit a new version for the missing signature.
+            indtypes = self._search_matching_signature(indtypes)
+            # Select kernel
+            outdtypes, kernel = self.kernelmap[indtypes]
+
+        # check output
+        for sched_shape, out in zip(schedule.output_shapes, outs):
+            if out is not None and sched_shape != out.shape:
+                raise ValueError("output shape mismatch")
+
+        return indtypes, schedule, outdtypes, kernel
+
+    def _search_matching_signature(self, idtypes):
+        """
+        Given the input types in `idtypes`, return a compatible sequence of
+        types that is defined in `kernelmap`.
+
+        Note: Ordering is guaranteed by `kernelmap` being a OrderedDict
+        """
+        for sig in self.kernelmap.keys():
+            if all(
+                np.can_cast(actual, desired)
+                for actual, desired in zip(sig, idtypes)
+            ):
+                return sig
+        else:
+            raise TypeError("no matching signature")
+
+    def _broadcast(self, schedule, params, retvals):
+        assert schedule.loopn > 0, "zero looping dimension"
+
+        odim = 1 if not schedule.loopdims else schedule.loopn
+        newparams = []
+        for p, cs in zip(params, schedule.ishapes):
+            if not cs and p.size == 1:
+                # Broadcast scalar input
+                devary = self._broadcast_scalar_input(p, odim)
+                newparams.append(devary)
+            else:
+                # Broadcast vector input
+                newparams.append(self._broadcast_array(p, odim, cs))
+
+        newretvals = []
+        for retval, oshape in zip(retvals, schedule.oshapes):
+            newretvals.append(retval.reshape(odim, *oshape))
+        return tuple(newparams) + tuple(newretvals)
+
+    def _broadcast_array(self, ary, newdim, innerdim):
+        newshape = (newdim,) + innerdim
+        # No change in shape
+        if ary.shape == newshape:
+            return ary
+
+        # Creating new dimension
+        elif len(ary.shape) < len(newshape):
+            assert newshape[-len(ary.shape) :] == ary.shape, (
+                "cannot add dim and reshape at the same time"
+            )
+            return self._broadcast_add_axis(ary, newshape)
+
+        # Collapsing dimension
+        else:
+            return ary.reshape(*newshape)
+
+    def _broadcast_add_axis(self, ary, newshape):
+        raise NotImplementedError("cannot add new axis")
+
+    def _broadcast_scalar_input(self, ary, shape):
+        raise NotImplementedError
+
+
+class GUFuncCallSteps(metaclass=ABCMeta):
+    """
+    Implements memory management and kernel launch operations for GUFunc calls.
+
+    One instance of this class is instantiated for each call, and the instance
+    is specific to the arguments given to the GUFunc call.
+
+    The base class implements the overall logic; subclasses provide
+    target-specific implementations of individual functions.
+    """
+
+    # The base class uses these slots; subclasses may provide additional slots.
+    __slots__ = [
+        "outputs",
+        "inputs",
+        "_copy_result_to_host",
+    ]
+
+    @abstractmethod
+    def launch_kernel(self, kernel, nelem, args):
+        """Implement the kernel launch"""
+
+    @abstractmethod
+    def is_device_array(self, obj):
+        """
+        Return True if `obj` is a device array for this target, False
+        otherwise.
+        """
+
+    @abstractmethod
+    def as_device_array(self, obj):
+        """
+        Return `obj` as a device array on this target.
+
+        May return `obj` directly if it is already on the target.
+        """
+
+    @abstractmethod
+    def to_device(self, hostary):
+        """
+        Copy `hostary` to the device and return the device array.
+        """
+
+    @abstractmethod
+    def allocate_device_array(self, shape, dtype):
+        """
+        Allocate a new uninitialized device array with the given shape and
+        dtype.
+        """
+
+    def __init__(self, nin, nout, args, kwargs):
+        outputs = kwargs.get("out")
+
+        # Ensure the user has passed a correct number of arguments
+        if outputs is None and len(args) not in (nin, (nin + nout)):
+
+            def pos_argn(n):
+                return f"{n} positional argument{'s' * (n != 1)}"
+
+            msg = (
+                f"This gufunc accepts {pos_argn(nin)} (when providing "
+                f"input only) or {pos_argn(nin + nout)} (when providing "
+                f"input and output). Got {pos_argn(len(args))}."
+            )
+            raise TypeError(msg)
+
+        if outputs is not None and len(args) > nin:
+            raise ValueError(
+                "cannot specify argument 'out' as both positional and keyword"
+            )
+        else:
+            # If the user did not pass outputs either in the out kwarg or as
+            # positional arguments, then we need to generate an initial list of
+            # "placeholder" outputs using None as a sentry value
+            outputs = [outputs] * nout
+
+        # Ensure all output device arrays are Numba device arrays - for
+        # example, any output passed in that supports the CUDA Array Interface
+        # is converted to a Numba CUDA device array; others are left untouched.
+        all_user_outputs_are_host = True
+        self.outputs = []
+        for output in outputs:
+            if self.is_device_array(output):
+                self.outputs.append(self.as_device_array(output))
+                all_user_outputs_are_host = False
+            else:
+                self.outputs.append(output)
+
+        all_host_arrays = not any([self.is_device_array(a) for a in args])
+
+        # - If any of the arguments are device arrays, we leave the output on
+        #   the device.
+        self._copy_result_to_host = (
+            all_host_arrays and all_user_outputs_are_host
+        )
+
+        # Normalize arguments - ensure they are either device- or host-side
+        # arrays (as opposed to lists, tuples, etc).
+        def normalize_arg(a):
+            if self.is_device_array(a):
+                convert = self.as_device_array
+            else:
+                convert = np.asarray
+
+            return convert(a)
+
+        normalized_args = [normalize_arg(a) for a in args]
+        self.inputs = normalized_args[:nin]
+
+        # Check if there are extra arguments for outputs.
+        unused_inputs = normalized_args[nin:]
+        if unused_inputs:
+            self.outputs = unused_inputs
+
+    def adjust_input_types(self, indtypes):
+        """
+        Attempt to cast the inputs to the required types if necessary
+        and if they are not device arrays.
+
+        Side effect: Only affects the elements of `inputs` that require
+        a type cast.
+        """
+        for i, (ity, val) in enumerate(zip(indtypes, self.inputs)):
+            if ity != val.dtype:
+                if not hasattr(val, "astype"):
+                    msg = (
+                        "compatible signature is possible by casting but "
+                        "{0} does not support .astype()"
+                    ).format(type(val))
+                    raise TypeError(msg)
+                # Cast types
+                self.inputs[i] = val.astype(ity)
+
+    def prepare_outputs(self, schedule, outdtypes):
+        """
+        Returns a list of output parameters that all reside on the target
+        device.
+
+        Outputs that were passed-in to the GUFunc are used if they reside on the
+        device; other outputs are allocated as necessary.
+        """
+        outputs = []
+        for shape, dtype, output in zip(
+            schedule.output_shapes, outdtypes, self.outputs
+        ):
+            if output is None or self._copy_result_to_host:
+                output = self.allocate_device_array(shape, dtype)
+            outputs.append(output)
+
+        return outputs
+
+    def prepare_inputs(self):
+        """
+        Returns a list of input parameters that all reside on the target device.
+        """
+
+        def ensure_device(parameter):
+            if self.is_device_array(parameter):
+                convert = self.as_device_array
+            else:
+                convert = self.to_device
+
+            return convert(parameter)
+
+        return [ensure_device(p) for p in self.inputs]
+
+    def post_process_outputs(self, outputs):
+        """
+        Moves the given output(s) to the host if necessary.
+
+        Returns a single value (e.g. an array) if there was one output, or a
+        tuple of arrays if there were multiple. Although this feels a little
+        jarring, it is consistent with the behavior of GUFuncs in general.
+        """
+        if self._copy_result_to_host:
+            outputs = [
+                self.to_host(output, self_output)
+                for output, self_output in zip(outputs, self.outputs)
+            ]
+        elif self.outputs[0] is not None:
+            outputs = self.outputs
+
+        if len(outputs) == 1:
+            return outputs[0]
+        else:
+            return tuple(outputs)

--- a/numba/hip/deviceufunc.py
+++ b/numba/hip/deviceufunc.py
@@ -1,23 +1,45 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+# MIT License
+#
+# Modifications Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 """
 Implements custom ufunc dispatch mechanism for non-CPU devices.
 """
 
-from abc import ABCMeta, abstractmethod
-from collections import OrderedDict
 import operator
 import warnings
+from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
 from functools import reduce
 
 import numpy as np
-
-from numba.np.ufunc.ufuncbuilder import _BaseUFuncBuilder, parse_identity
 from numba.core import types
 from numba.core.typing import signature
-from numba.cuda.core import sigutils
 from numba.np.ufunc.sigparse import parse_signature
+from numba.np.ufunc.ufuncbuilder import _BaseUFuncBuilder, parse_identity
+
+from numba.hip.core import sigutils
 
 
 def _broadcast_axis(a, b):
@@ -518,7 +540,9 @@ def _determine_gufunc_outer_types(argtys, dims):
             yield at.copy(ndim=nd + 1)
         else:
             if nd > 0:
-                raise ValueError("gufunc signature mismatch: ndim>0 for scalar")
+                raise ValueError(
+                    "gufunc signature mismatch: ndim>0 for scalar"
+                )
             yield types.Array(dtype=at, ndim=1, layout="A")
 
 
@@ -536,7 +560,7 @@ def expand_gufunc_template(template, indims, outdims, funcname, argtypes):
     outputs = [
         _gen_src_for_indexing(aref, adims, atype)
         for aref, adims, atype in zip(
-            argnames[len(indims) :], outdims, argtypes[len(indims) :]
+            argnames[len(indims):], outdims, argtypes[len(indims):]
         )
     ]
     argitems = inputs + outputs
@@ -753,9 +777,9 @@ class GeneralizedUFunc(object):
 
         # Creating new dimension
         elif len(ary.shape) < len(newshape):
-            assert newshape[-len(ary.shape) :] == ary.shape, (
-                "cannot add dim and reshape at the same time"
-            )
+            assert (
+                newshape[-len(ary.shape) :] == ary.shape
+            ), "cannot add dim and reshape at the same time"
             return self._broadcast_add_axis(ary, newshape)
 
         # Collapsing dimension

--- a/numba/hip/dispatcher.py
+++ b/numba/hip/dispatcher.py
@@ -821,9 +821,7 @@ class HIPDispatcher(Dispatcher, serialize.ReduceMixin):
         *args*.
         """
         amdgpu_arch = get_current_device().amdgpu_arch
-        argtypes = tuple(
-            [self.typingctx.resolve_argument_type(a) for a in args]
-        )
+        argtypes = tuple(self.typeof_pyval(a) for a in args)
         if self.specialized:
             raise RuntimeError("Dispatcher already specialized")
 

--- a/numba/hip/dispatcher.py
+++ b/numba/hip/dispatcher.py
@@ -25,7 +25,7 @@
 
 # MIT License
 #
-# Modifications Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Modifications Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -51,7 +51,7 @@ import sys
 from warnings import warn
 
 import numpy as np
-from numba.core import config, serialize, sigutils, types, typing, utils
+from numba.core import config, serialize, types, typing, utils
 from numba.core.caching import Cache, CacheImpl
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher
@@ -62,6 +62,7 @@ from numba import _dispatcher, hip
 from numba.hip.api import get_current_device
 from numba.hip.args import wrap_arg
 from numba.hip.compiler import HIPCompiler, compile_hip
+from numba.hip.core import sigutils
 from numba.hip.descriptor import hip_target
 from numba.hip.errors import (
     missing_launch_config_msg,

--- a/numba/hip/hipconfig.py
+++ b/numba/hip/hipconfig.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Modifications Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Modifications Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -64,6 +64,9 @@ Attributes (Controllable via Environment Variables ``NUMBA_HIP_<attribute>``):
         an unusual name. If this environment variable
         is set, NUMBA_HIP_LIBCLANG_PATH will be
         ignored.
+    FALLBACK_TO_AMDSMI_FOR_UUID (`bool`):
+        If set to ``True``, when obtaining the GPU UUID via the HIP runtime
+        fails, Numba will attempt to obtain the GPU UUID via AMD's AMD System Management Interface (AMDSMI) library. Defaults to ``False``.
 Note:
     We currently don't want to break out of subfolder
     ``numba/hip``with the changes that we apply to an
@@ -113,6 +116,10 @@ MINIMIZE_IR = bool(
 
 LIBCLANG_PATH = os.environ.get("NUMBA_HIP_LIBCLANG_PATH", None)
 LIBCLANG_FILE = os.environ.get("NUMBA_HIP_LIBCLANG_FILE", None)
+
+FALLBACK_TO_AMDSMI_FOR_UUID = bool(
+    int(os.environ.get("NUMBA_HIP_FALLBACK_TO_AMDSMI_FOR_UUID", False))
+)
 
 
 def get_rocm_path(*subdirs):

--- a/numba/hip/hipdrv/__init__.py
+++ b/numba/hip/hipdrv/__init__.py
@@ -25,7 +25,7 @@
 
 # MIT License
 #
-# Modifications Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Modifications Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -62,27 +62,18 @@ assert not config.ENABLE_CUDASIM, "Cannot use real driver API with simulator"
 # Now follow the modules
 # -----------------------
 
-import os  # noqa: E402
-import re  # noqa: E402
-
-import numba.hip.util.modulerepl as _modulerepl  # noqa: E402
-
-mr = _modulerepl.ModuleReplicator(
-    "numba.hip.hipdrv",
-    os.path.join(os.path.dirname(__file__), "..", "..", "cuda", "cudadrv"),
-    base_context=globals(),
-    preprocess_all=lambda content: re.sub(  # noqa: F821
-        r"\bnumba.cuda\b", "numba.hip", content
-    ).replace("cudadrv", "hipdrv"),
-)
-
 # order is important here!
 
-from . import _extras, hiprtc  # noqa: E402, F401
+
+from . import _extras  # noqa: E402, F401
+from . import devicearray  # noqa: E402, F401
+from . import devices  # noqa: E402, F401
+from . import driver  # noqa: E402, F401
+from . import error  # noqa: E402, F401
+from . import hiprtc  # noqa: E402, F401
 
 nvrtc = hiprtc
-
-from . import driver  # noqa: E402, F401
+from . import ndarray  # noqa: E402, F401
 
 # DOCS 'devices':
 # Expose each GPU devices directly.
@@ -94,26 +85,3 @@ from . import driver  # noqa: E402, F401
 #
 # Note:
 # - This module must be imported by the main-thread.
-
-devices = mr.create_and_register_derived_module(
-    "devices",
-)  # make this a submodule of the package
-
-devicearray = mr.create_and_register_derived_module(
-    "devicearray",
-    preprocess=lambda content: content.replace(
-        "from numba import cuda", "from numba import hip as cuda"
-    ),
-    # preprocess=lambda content: content.replace("CUDA","HIP")
-    # Reuse CUDA config values as they are for now: config.CUDA_WARN_ON_IMPLICIT_COPY
-)  # make this a submodule of the package
-
-ndarray = mr.create_and_register_derived_module(
-    "ndarray",
-)  # make this a submodule of the package
-
-# clean up
-del mr
-del _modulerepl
-del os
-del re

--- a/numba/hip/hipdrv/devicearray.py
+++ b/numba/hip/hipdrv/devicearray.py
@@ -65,12 +65,11 @@ import numpy as np
 
 import numba
 from numba import _devicearray
-from numba.hip.hipdrv import devices
+from numba.hip.hipdrv import devices, dummyarray
 from numba.hip.hipdrv import driver as _driver
 from numba.core import types, config
 from numba.np.unsafe.ndarray import to_fixed_tuple
 from numba.np.numpy_support import numpy_version
-from numba.misc import dummyarray
 from numba.np import numpy_support
 from numba.hip.api_util import prepare_shape_strides_dtype
 from numba.core.errors import NumbaPerformanceWarning

--- a/numba/hip/hipdrv/devicearray.py
+++ b/numba/hip/hipdrv/devicearray.py
@@ -25,7 +25,7 @@
 
 # MIT License
 #
-# Modifications Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Modifications Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -621,10 +621,13 @@ class DeviceNDArray(DeviceNDArrayBase):
         '''
         return self._dummy.is_c_contig
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """
         :return: an `numpy.ndarray`, so copies to the host.
         """
+        if copy is False:
+            msg = "`copy=False` is not supported. A copy is always created."
+            raise ValueError(msg)
         if dtype:
             return self.copy_to_host().__array__(dtype)
         else:

--- a/numba/hip/hipdrv/driver.py
+++ b/numba/hip/hipdrv/driver.py
@@ -25,7 +25,7 @@
 
 # MIT License
 #
-# Modifications Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Modifications Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -163,7 +163,9 @@ class HipAPIError(HipRuntimeError):
     def __str__(self):
         return "[%s] %s" % (self.code, self.msg)
 
+
 CudaAPIError = HipAPIError  #: HIP/AMD: alias
+
 
 def locate_runtime_and_loader():  #: HIP/AMD: modified body
     # envpath = config.CUDA_DRIVER
@@ -547,6 +549,45 @@ class Device(object):
             ).format(identity)
             raise RuntimeError(errmsg)
 
+    @staticmethod
+    def _get_uuid_via_amdsmi():
+        """Obtain GPU UUID via AMD SMI as a fallback when the UUID obtained from the driver is not in the expected format."""
+        import json
+        import subprocess
+
+        # note: we assume 'amd-smi' is in PATH
+        #       and that there is only a single GPU
+        #       in the system.
+        if driver.get_device_count() != 1:
+            raise RuntimeError(
+                "Fallback to AMD SMI for UUID is only supported for single-GPU systems."
+            )
+        result = subprocess.run(
+            ["amd-smi", "list", "-g", "0", "--json"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                "Failed to run 'amd-smi list' while obtaining GPU UUID. "
+                f"Exit code: {result.returncode}\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+        # Typical stdout output looks like:
+        # ```
+        # [
+        #     {
+        #         "gpu": 0,
+        #         ...
+        #         "uuid": "<the-uuid>",
+        #         ...
+        #     }
+        # ]
+        # ```
+        return json.loads(result.stdout)[0]["uuid"]
+
     def __init__(self, devnum):
         result = driver.cuDeviceGet(devnum)
         self.id = result
@@ -578,15 +619,30 @@ class Device(object):
         self.name = name
 
         # Read UUID
-        uuid = driver.cuDeviceGetUuid(self.id)
+        uuid = driver.cuDeviceGetUuid(self.id)  # type: bytes
         uuid_vals = tuple(uuid.bytes)
 
-        b = "%02x"
-        b2 = b * 2
-        b4 = b * 4
-        b6 = b * 6
-        fmt = f"GPU-{b4}-{b2}-{b2}-{b2}-{b6}"
-        self.uuid = fmt % uuid_vals
+        try:
+            b = "%02x"
+            b2 = b * 2
+            b4 = b * 4
+            b6 = b * 6
+            fmt = f"GPU-{b4}-{b2}-{b2}-{b2}-{b6}"
+            self.uuid = fmt % uuid_vals
+        except TypeError as formatting_error:
+            if hipconfig.FALLBACK_TO_AMDSMI_FOR_UUID:
+                self.uuid = "GPU-" + Device._get_uuid_via_amdsmi()
+            else:
+                _logger.error(
+                    f"Device UUID '{uuid.decode()}' is not in "
+                    "the expected format. You can try setting the "
+                    "environment variable "
+                    "NUMBA_HIP_FALLBACK_TO_AMDSMI_FOR_UUID=1 to "
+                    "obtain the UUID via AMD SMI as a fallback,"
+                    "but note that this is only supported for "
+                    "single-GPU systems."
+                )
+                raise formatting_error
 
         self.primary_context = None
 

--- a/numba/hip/hipdrv/dummyarray.py
+++ b/numba/hip/hipdrv/dummyarray.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from collections import namedtuple
+import itertools
+import functools
+import operator
+import ctypes
+
+import numpy as np
+
+from numba import _helperlib
+
+Extent = namedtuple("Extent", ["begin", "end"])
+
+attempt_nocopy_reshape = ctypes.CFUNCTYPE(
+	ctypes.c_int,
+	ctypes.c_long,  # nd
+	np.ctypeslib.ndpointer(np.ctypeslib.c_intp, ndim=1),  # dims
+	np.ctypeslib.ndpointer(np.ctypeslib.c_intp, ndim=1),  # strides
+	ctypes.c_long,  # newnd
+	np.ctypeslib.ndpointer(np.ctypeslib.c_intp, ndim=1),  # newdims
+	np.ctypeslib.ndpointer(np.ctypeslib.c_intp, ndim=1),  # newstrides
+	ctypes.c_long,  # itemsize
+	ctypes.c_int,  # is_f_order
+)(_helperlib.c_helpers["attempt_nocopy_reshape"])
+
+
+class Dim(object):
+	__slots__ = "start", "stop", "size", "stride", "single"
+
+	def __init__(self, start, stop, size, stride, single):
+		self.start = start
+		self.stop = stop
+		self.size = size
+		self.stride = stride
+		self.single = single
+		assert not single or size == 1
+
+	def __getitem__(self, item):
+		if isinstance(item, slice):
+			start, stop, step = item.indices(self.size)
+			stride = step * self.stride
+			start = self.start + start * abs(self.stride)
+			stop = self.start + stop * abs(self.stride)
+			if stride == 0:
+				size = 1
+			else:
+				size = _compute_size(start, stop, stride)
+			ret = Dim(
+				start=start, stop=stop, size=size, stride=stride, single=False
+			)
+			return ret
+		else:
+			sliced = self[item : item + 1] if item != -1 else self[-1:]
+			if sliced.size != 1:
+				raise IndexError
+			return Dim(
+				start=sliced.start,
+				stop=sliced.stop,
+				size=sliced.size,
+				stride=sliced.stride,
+				single=True,
+			)
+
+	def get_offset(self, idx):
+		return self.start + idx * self.stride
+
+	def __repr__(self):
+		strfmt = "Dim(start=%s, stop=%s, size=%s, stride=%s)"
+		return strfmt % (self.start, self.stop, self.size, self.stride)
+
+	def normalize(self, base):
+		return Dim(
+			start=self.start - base,
+			stop=self.stop - base,
+			size=self.size,
+			stride=self.stride,
+			single=self.single,
+		)
+
+	def copy(self, start=None, stop=None, size=None, stride=None, single=None):
+		if start is None:
+			start = self.start
+		if stop is None:
+			stop = self.stop
+		if size is None:
+			size = self.size
+		if stride is None:
+			stride = self.stride
+		if single is None:
+			single = self.single
+		return Dim(start, stop, size, stride, single)
+
+	def is_contiguous(self, itemsize):
+		return self.stride == itemsize
+
+
+def compute_index(indices, dims):
+	return sum(d.get_offset(i) for i, d in zip(indices, dims))
+
+
+class Element(object):
+	is_array = False
+
+	def __init__(self, extent):
+		self.extent = extent
+
+	def iter_contiguous_extent(self):
+		yield self.extent
+
+
+class Array(object):
+	is_array = True
+
+	@classmethod
+	def from_desc(cls, offset, shape, strides, itemsize):
+		dims = []
+		for ashape, astride in zip(shape, strides):
+			dim = Dim(
+				offset, offset + ashape * astride, ashape, astride, single=False
+			)
+			dims.append(dim)
+			offset = 0
+		return cls(dims, itemsize)
+
+	def __init__(self, dims, itemsize):
+		self.dims = tuple(dims)
+		self.ndim = len(self.dims)
+		self.shape = tuple(dim.size for dim in self.dims)
+		self.strides = tuple(dim.stride for dim in self.dims)
+		self.itemsize = itemsize
+		self.size = functools.reduce(operator.mul, self.shape, 1)
+		self.extent = self._compute_extent()
+		self.flags = self._compute_layout()
+
+	def _compute_layout(self):
+		if not self.dims:
+			return {"C_CONTIGUOUS": True, "F_CONTIGUOUS": True}
+		if any([dim.stride == 0 for dim in self.dims]):
+			return {"C_CONTIGUOUS": False, "F_CONTIGUOUS": False}
+		flags = {"C_CONTIGUOUS": True, "F_CONTIGUOUS": True}
+		sd = self.itemsize
+		for dim in reversed(self.dims):
+			if dim.size == 0:
+				return {"C_CONTIGUOUS": True, "F_CONTIGUOUS": True}
+			if dim.size != 1:
+				if dim.stride != sd:
+					flags["C_CONTIGUOUS"] = False
+				sd *= dim.size
+		sd = self.itemsize
+		for dim in self.dims:
+			if dim.size != 1:
+				if dim.stride != sd:
+					flags["F_CONTIGUOUS"] = False
+					return flags
+				sd *= dim.size
+		return flags
+
+	def _compute_extent(self):
+		firstidx = [0] * self.ndim
+		lastidx = [s - 1 for s in self.shape]
+		start = compute_index(firstidx, self.dims)
+		stop = compute_index(lastidx, self.dims) + self.itemsize
+		stop = max(stop, start)
+		return Extent(start, stop)
+
+	def __repr__(self):
+		return "<Array dims=%s itemsize=%s>" % (self.dims, self.itemsize)
+
+	def __getitem__(self, item):
+		if not isinstance(item, tuple):
+			item = [item]
+		else:
+			item = list(item)
+		nitem = len(item)
+		ndim = len(self.dims)
+		if nitem > ndim:
+			raise IndexError("%d extra indices given" % (nitem - ndim,))
+		while len(item) < ndim:
+			item.append(slice(None, None))
+		dims = [dim.__getitem__(it) for dim, it in zip(self.dims, item)]
+		newshape = [d.size for d in dims if not d.single]
+		arr = Array(dims, self.itemsize)
+		if newshape:
+			return arr.reshape(*newshape)[0]
+		else:
+			return Element(arr.extent)
+
+	@property
+	def is_c_contig(self):
+		return self.flags["C_CONTIGUOUS"]
+
+	@property
+	def is_f_contig(self):
+		return self.flags["F_CONTIGUOUS"]
+
+	def iter_contiguous_extent(self):
+		if self.is_c_contig or self.is_f_contig:
+			yield self.extent
+		else:
+			if self.dims[0].stride < self.dims[-1].stride:
+				innerdim = self.dims[0]
+				outerdims = self.dims[1:]
+				outershape = self.shape[1:]
+			else:
+				innerdim = self.dims[-1]
+				outerdims = self.dims[:-1]
+				outershape = self.shape[:-1]
+			if innerdim.is_contiguous(self.itemsize):
+				oslen = [range(s) for s in outershape]
+				for indices in itertools.product(*oslen):
+					base = compute_index(indices, outerdims)
+					yield base + innerdim.start, base + innerdim.stop
+			else:
+				oslen = [range(s) for s in self.shape]
+				for indices in itertools.product(*oslen):
+					offset = compute_index(indices, self.dims)
+					yield offset, offset + self.itemsize
+
+	def reshape(self, *newdims, **kws):
+		oldnd = self.ndim
+		newnd = len(newdims)
+		if newdims == self.shape:
+			return self, None
+		order = kws.pop("order", "C")
+		if kws:
+			raise TypeError("unknown keyword arguments %s" % kws.keys())
+		if order not in "CFA":
+			raise ValueError("order not C|F|A")
+		unknownidx = -1
+		knownsize = 1
+		for i, dim in enumerate(newdims):
+			if dim < 0:
+				if unknownidx == -1:
+					unknownidx = i
+				else:
+					raise ValueError("can only specify one unknown dimension")
+			else:
+				knownsize *= dim
+		if unknownidx >= 0:
+			if knownsize == 0 or self.size % knownsize != 0:
+				raise ValueError(
+					"cannot infer valid shape for unknown dimension"
+				)
+			else:
+				newdims = (
+					newdims[0:unknownidx]
+					+ (self.size // knownsize,)
+					+ newdims[unknownidx + 1 :]
+				)
+		newsize = functools.reduce(operator.mul, newdims, 1)
+		if order == "A":
+			order = "F" if self.is_f_contig else "C"
+		if newsize != self.size:
+			raise ValueError("reshape changes the size of the array")
+		if self.is_c_contig or self.is_f_contig:
+			if order == "C":
+				newstrides = list(iter_strides_c_contig(self, newdims))
+			elif order == "F":
+				newstrides = list(iter_strides_f_contig(self, newdims))
+			else:
+				raise AssertionError("unreachable")
+		else:
+			newstrides = np.empty(newnd, np.ctypeslib.c_intp)
+			olddims = np.array(self.shape, dtype=np.ctypeslib.c_intp)
+			oldstrides = np.array(self.strides, dtype=np.ctypeslib.c_intp)
+			newdims = np.array(newdims, dtype=np.ctypeslib.c_intp)
+			if not attempt_nocopy_reshape(
+				oldnd,
+				olddims,
+				oldstrides,
+				newnd,
+				newdims,
+				newstrides,
+				self.itemsize,
+				order == "F",
+			):
+				raise NotImplementedError("reshape would require copy")
+		ret = self.from_desc(
+			self.extent.begin,
+			shape=newdims,
+			strides=newstrides,
+			itemsize=self.itemsize,
+		)
+		return ret, list(self.iter_contiguous_extent())
+
+	def squeeze(self, axis=None):
+		newshape, newstrides = [], []
+		if axis is None:
+			for length, stride in zip(self.shape, self.strides):
+				if length != 1:
+					newshape.append(length)
+					newstrides.append(stride)
+		else:
+			if not isinstance(axis, tuple):
+				axis = (axis,)
+			for ax in axis:
+				if self.shape[ax] != 1:
+					raise ValueError(
+						"cannot select an axis to squeeze out which has size "
+						"not equal to one"
+					)
+			for i, (length, stride) in enumerate(zip(self.shape, self.strides)):
+				if i not in axis:
+					newshape.append(length)
+					newstrides.append(stride)
+		newarr = self.from_desc(
+			self.extent.begin,
+			shape=newshape,
+			strides=newstrides,
+			itemsize=self.itemsize,
+		)
+		return newarr, list(self.iter_contiguous_extent())
+
+	def ravel(self, order="C"):
+		if order not in "CFA":
+			raise ValueError("order not C|F|A")
+		if (
+			order in "CA"
+			and self.is_c_contig
+			or order in "FA"
+			and self.is_f_contig
+		):
+			newshape = (self.size,)
+			newstrides = (self.itemsize,)
+			arr = self.from_desc(
+				self.extent.begin, newshape, newstrides, self.itemsize
+			)
+			return arr, list(self.iter_contiguous_extent())
+		else:
+			raise NotImplementedError("ravel on non-contiguous array")
+
+
+def iter_strides_f_contig(arr, shape=None):
+	shape = arr.shape if shape is None else shape
+	itemsize = arr.itemsize
+	yield itemsize
+	sum = 1
+	for s in shape[:-1]:
+		sum *= s
+		yield sum * itemsize
+
+
+def iter_strides_c_contig(arr, shape=None):
+	shape = arr.shape if shape is None else shape
+	itemsize = arr.itemsize
+	def gen():
+		yield itemsize
+		sum = 1
+		for s in reversed(shape[1:]):
+			sum *= s
+			yield sum * itemsize
+	for i in reversed(list(gen())):
+		yield i
+
+
+def is_element_indexing(item, ndim):
+	if isinstance(item, slice):
+		return False
+	elif isinstance(item, tuple):
+		if len(item) == ndim:
+			if not any(isinstance(it, slice) for it in item):
+				return True
+	else:
+		return True
+	return False
+
+
+def _compute_size(start, stop, step):
+	if step > 0:
+		lo = start
+		hi = stop
+	else:
+		lo = stop
+		hi = start
+		step = -step
+	if lo >= hi:
+		return 0
+	return (hi - lo - 1) // step + 1
+

--- a/numba/hip/tests/hipdrv/test_hip_array_slicing.py
+++ b/numba/hip/tests/hipdrv/test_hip_array_slicing.py
@@ -25,7 +25,7 @@
 
 # MIT License
 #
-# Modifications Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Modifications Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -278,7 +278,7 @@ class CudaArraySlicing(CUDATestCase):
         for i in range(darr.shape[0]):
             np.testing.assert_array_equal(darr[i:i].copy_to_host(), arr[i:i])
         # empty slice of empty slice
-        self.assertFalse(darr[:0][:0].copy_to_host())
+        self.assertFalse(darr[:0][:0].copy_to_host().size > 0)
         # out-of-bound slice just produces empty slices
         np.testing.assert_array_equal(darr[:0][:1].copy_to_host(), arr[:0][:1])
         np.testing.assert_array_equal(
@@ -291,7 +291,7 @@ class CudaArraySlicing(CUDATestCase):
         np.testing.assert_array_equal(darr[:0].copy_to_host(), arr[:0])
         np.testing.assert_array_equal(darr[3, :0].copy_to_host(), arr[3, :0])
         # empty slice of empty slice
-        self.assertFalse(darr[:0][:0].copy_to_host())
+        self.assertFalse(darr[:0][:0].copy_to_host().size > 0)
         # out-of-bound slice just produces empty slices
         np.testing.assert_array_equal(darr[:0][:1].copy_to_host(), arr[:0][:1])
         np.testing.assert_array_equal(

--- a/numba/hip/tests/hipdrv/test_hip_ndarray.py
+++ b/numba/hip/tests/hipdrv/test_hip_ndarray.py
@@ -25,7 +25,7 @@
 
 # MIT License
 #
-# Modifications Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Modifications Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -48,12 +48,15 @@
 import itertools
 
 import numpy as np
+from numba.np.numpy_support import numpy_version
 
 from numba import hip as cuda
 from numba.hip.hipdrv import devicearray
 from numba.hip.testing import HIPTestCase as CUDATestCase
 from numba.hip.testing import skip_on_hipsim as skip_on_cudasim
 from numba.hip.testing import unittest
+
+IS_NUMPY_2 = numpy_version >= (2, 0)
 
 
 class TestCudaNDArray(CUDATestCase):
@@ -511,6 +514,37 @@ class TestCudaNDArray(CUDATestCase):
 
         dev_array.copy_to_device(dev_array_from_host)
         dev_array_from_host.copy_to_device(dev_array)
+
+
+class TestArrayMethod(CUDATestCase):
+    """Tests of the __array__() method via np.array"""
+
+    def test_np_array(self):
+        dev_array = cuda.to_device(np.asarray([1.0, 2.0, 3.0]))
+        host_array = np.array(dev_array)
+        np.testing.assert_equal(dev_array.copy_to_host(), host_array)
+
+    def test_np_array_dtype(self):
+        dtype = np.int32
+        dev_array = cuda.to_device(np.asarray([1.0, 2.0, 3.0]))
+        host_array = np.array(dev_array, dtype=dtype)
+        np.testing.assert_equal(
+            host_array, dev_array.copy_to_host().astype(dtype)
+        )
+
+    @skip_on_cudasim("Simulator does not use __array__()")
+    @unittest.skipUnless(IS_NUMPY_2, "NumPy 1.x does not pass copy kwarg")
+    def test_np_array_copy_false(self):
+        dev_array = cuda.to_device(np.asarray([1.0, 2.0, 3.0]))
+        with self.assertRaisesRegex(ValueError, "`copy=False` is not"):
+            np.array(dev_array, copy=False)
+
+    @skip_on_cudasim("Simulator does not use __array__()")
+    @unittest.skipUnless(IS_NUMPY_2, "NumPy 1.x does not pass copy kwarg")
+    def test_np_array_copy_true(self):
+        dev_array = cuda.to_device(np.asarray([1.0, 2.0, 3.0]))
+        host_array = np.array(dev_array)
+        np.testing.assert_equal(dev_array.copy_to_host(), host_array)
 
 
 class TestRecarray(CUDATestCase):

--- a/numba/hip/tests/util/test_amdgcn.py
+++ b/numba/hip/tests/util/test_amdgcn.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S python3 -m pytest -v -s
 # MIT License
 #
-# Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@ def test_00_print_datalayout():
         "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7",
         "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8",
         "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9",  # ROCm 6.2.0
+        "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9",  # ROCm 7.2
     )
 
 
@@ -46,10 +47,10 @@ def test_01_verify_module():
     import faulthandler
 
     try:
-      faulthandler.enable()
+        faulthandler.enable()
     except Exception as e:
-      msg = "Failed to enable faulthandler due to:\n{err}"
-      warnings.warn(msg.format(err=e))
+        msg = "Failed to enable faulthandler due to:\n{err}"
+        warnings.warn(msg.format(err=e))
     machine = AMDGPUTargetMachine(target_cpu="gfx90a")
 
     dep_llvm_ir = textwrap.dedent(

--- a/numba/hip/vectorizers.py
+++ b/numba/hip/vectorizers.py
@@ -22,9 +22,9 @@
 
 from numba import hip as cuda
 from numpy import array as np_array
-from numba.np.ufunc import deviceufunc
-from numba.np.ufunc.deviceufunc import (UFuncMechanism, GeneralizedUFunc,
-                                        GUFuncCallSteps)
+from numba.hip import deviceufunc
+from numba.hip.deviceufunc import (UFuncMechanism, GeneralizedUFunc,
+                                   GUFuncCallSteps)
 
 
 class CUDAUFuncDispatcher(object):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 [project]
 name = "numba-hip"
 version = "0.1.3"
@@ -13,10 +35,13 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [
-    "numba>=0.58,<0.61",
+    "numba>=0.58,<0.62",
     "hip-python>=6.3.0",
     "hip-python-as-cuda>=6.3.0",
     "rocm-llvm-python>=6.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@
 
 [project]
 name = "numba-hip"
-version = "0.1.3"
+version = "0.1.4"
 description = "Numba HIP - Numba backend for AMD GPUs"
 readme = { file = "README.rst", content-type = "text/x-rst" }
 authors = [{ name = "Advanced Micro Devices, Inc." }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,7 @@
 
 [project]
 name = "numba-hip"
-version = "0.1.4"
+version = "0.1.5"
 description = "Numba HIP - Numba backend for AMD GPUs"
 readme = { file = "README.rst", content-type = "text/x-rst" }
 authors = [{ name = "Advanced Micro Devices, Inc." }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@
 
 [project]
 name = "numba-hip"
-version = "0.1.5"
+version = "0.1.6"
 description = "Numba HIP - Numba backend for AMD GPUs"
 readme = { file = "README.rst", content-type = "text/x-rst" }
 authors = [{ name = "Advanced Micro Devices, Inc." }]
@@ -50,6 +50,16 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest", "cffi"]
 dev = ["pytest", "cffi"]
+rocm-7-2-0 = [
+    "hip-python~=7.2.0.0",
+    "hip-python-as-cuda~=7.2.0.0",
+    "rocm-llvm-python~=7.2.0.0",
+]
+rocm-7-1-1 = [
+    "hip-python~=7.1.1.0",
+    "hip-python-as-cuda~=7.1.1.0",
+    "rocm-llvm-python~=7.1.1.0",
+]
 rocm-7-1-0 = [
     "hip-python~=7.1.0.0",
     "hip-python-as-cuda~=7.1.0.0",


### PR DESCRIPTION
This PR applies three patch updates from the internal repository to the public repo's' `dev` branch.

## Highlights

* Python 3.13 compatibility
* ROCm 7.1.1. and 7.2.0 compatibility
* NumPy 2.0 compatibility
* Numba 0.61.2 compatibility
* Implements a workaround for #7 

## Changes (via CHANGELOG.md)

```
# numba-hip 0.1.6 (09 Feb 2026)

* Add fallback option to use AMD-SMI for UUID detection.
* Extend ROCm support metadata with keys for ROCm 7.1.1 and 7.2.0.
* Documentation: update tested GPUs and supported Numba versions.

# numba-hip 0.1.5 (29 Jan 2026)

## Bug Fixes

* Fix `__array__()` method for NumPy 2.0 compatibility.
* Add ROCm 7.2 data layout to `test_amdgcn`.

# numba-hip 0.1.4 (09 Dec 2025)

* Add Python 3.13 compatibility.
* Vendor HIP sigutils and switch HIP modules to use it.
* Move `devicefunc` and `dummyarray` into numba-hip.
* hipdrv: remove `modulerepl*`, use local module files.
* Documentation: extend support note with tested RDNA3/4 cards.
* Developer tooling: add `license_verificator` to pre-commit hooks.

## Bug Fixes

* Fix HIPDispatcher specialization typing to use `typeof_pyval`.
* tests(hipdrv): fix empty-slice assertions to validate array size.
```

## Test Result

Typical test result with expected number of successful / failing tests (gfx1102):

<img width="1672" height="1007" alt="image" src="https://github.com/user-attachments/assets/06c4d406-4413-485d-8ac7-6b7cbf90b2ac" />

> [!NOTE]
> Tests were executed on a shared test system. The test timings may vary based on hardware, OS, and system load.

Successfully tested AMD GPU architectures/devices:

* gfx1030v 
* gfx1100p 
* gfx1100w 
* gfx1102
* gfx1201 
* gfx90a-mi210x 
* gfx90a-mi250 
* gfx942-mi300a 
* gfx942-mi300x 
* gfx942-mi308x 
* gfx942-mi325x

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
