### PR TITLE
Update context.synchronize to use hipDeviceSynchronize() + testcase

### DIFF
--- a/numba/hip/hipdrv/driver.py
+++ b/numba/hip/hipdrv/driver.py
@@ -1487,7 +1487,7 @@ class Context(object):
         )
 
     def synchronize(self):
-        driver.cuCtxSynchronize()
+        driver.hipDeviceSynchronize()
 
     @contextlib.contextmanager
     def defer_cleanup(self):

--- a/numba/hip/tests/hipdrv/test_hip_driver.py
+++ b/numba/hip/tests/hipdrv/test_hip_driver.py
@@ -281,6 +281,13 @@ class TestCudaDriver(HIPTestCase):
         self.assertTrue(block > 0)
 
 
+    def test_context_synchronize(self):
+        # Test that context synchronization completes without error
+        # Must not call the deprecated hipCtxSynchronize,
+        # which returns hipErrorNotSupported on ROCm 7.0.2+
+        self.context.synchronize()
+
+
 class TestDevice(HIPTestCase):
     def test_device_get_uuid(self):
         # A device UUID looks like:


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/numba-hip/issues/12

## Technical Details

`context.synchronize` currently defaults to cuCtxSynchronize/hipCtxSynchronize  which has been deprecated in ROCm 7.0.2+. This results in the following error 

```

  File "/opt/venv/lib/python3.12/site-packages/numba/hip/hipdrv/driver.py", line 412, in _check_cuda_python_error
    raise HipAPIError(retcode, msg)
numba.hip.hipdrv.driver.HipAPIError: [801] Call to cuCtxSynchronize results in hipErrorNotSupported

```



Changes update synchronize method to correctly use hipDeviceSynchronize() and add a relevant testcase to `tests/hipdrv/test_hip_driver.py` for future validation.

## Test Plan

- Test using basic context.synchronize call in test_hip_driver.py.

## Test Result

- Before fix: test_context_synchronize — FAILED with hipErrorNotSupported (801)
- After fix: All 10 tests — OK 

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
